### PR TITLE
Allow 204s

### DIFF
--- a/src/main/java/net/interfax/rest/client/impl/DefaultInterFAXClient.java
+++ b/src/main/java/net/interfax/rest/client/impl/DefaultInterFAXClient.java
@@ -390,11 +390,14 @@ public class DefaultInterFAXClient extends AbstractInterFAXClient implements Int
                     .header("Range", "bytes="+startByteRange+"-"+endByteRange)
                     .post(Entity.entity(bytesToUpload, MediaType.APPLICATION_OCTET_STREAM_TYPE));
 
-            int expectedResponseCode = lastChunk ?
-                                        Response.Status.OK.getStatusCode():
-                                        Response.Status.ACCEPTED.getStatusCode();
 
-            if (response.getStatus() == expectedResponseCode) {
+            final int OK = Response.Status.OK.getStatusCode();
+            final int ACCEPTED = Response.Status.ACCEPTED.getStatusCode();
+            final int NO_CONTENT = Response.Status.NO_CONTENT.getStatusCode(); // 204: No content
+
+
+            if ((lastChunk && response.getStatus() == OK) ||
+                (!lastChunk && (response.getStatus() == ACCEPTED || response.getStatus() == NO_CONTENT))) {
                 log.info(
                         "chunk uploaded at {}; totalByesUploaded = {}; lastChunk = {}",
                         uploadChunkToDocumentEndpoint,


### PR DESCRIPTION
The current code code of the uploadChunk method allowed
200 and 202 as valid response codes. However, the server
also sends 204s and the method incorrectly identified
this as an error. This commit corrects that.